### PR TITLE
[Sprint 124] IFS-4526 isy task Logeintrag fehlerhaft 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.0.0
 - `IFS-4576`: Portierung fehlender Tickets aus isy-standards
-- 
+- `IFS-4526`: Logeintrag IsyTaskAspect korrigiert
+
 # 4.0.0
 - `IFS-2395`: Umstellung von IsyFact `MessageSourceHolder` auf Spring `MessageSource`
 - `IFS-4329`: IsyTaskAutoConfiguration verhindert jetzt Task-Erstellung im Batch-Profil

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 
 ### Umgesetzte Tickets
 - `IFS-4575`: Portierung fehlender Tickets aus isy-standards
+- `IFS-4526`: Logeintrag IsyTaskAspect korrigiert
 
 #### Bug Fixes
 - keine

--- a/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
+++ b/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
@@ -48,7 +48,6 @@ import java.util.regex.PatternSyntaxException;
 
 import static de.bund.bva.isyfact.task.konstanten.HinweisSchluessel.VERWENDE_STANDARD_KONFIGURATION;
 import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.*;
-import static java.text.MessageFormat.format;
 
 @Aspect
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -123,7 +122,7 @@ public class IsyTaskAspect {
             host = taskConfig.getHost();
             if (host == null) {
                 String nachricht = messageSource.getMessage(VERWENDE_STANDARD_KONFIGURATION, new String[] { taskId, "hostname" }, Locale.GERMANY);
-                logger.info(createKategorieMarker(KATEGORIE_JOURNAL), format("{0} {1}", VERWENDE_STANDARD_KONFIGURATION, nachricht));
+                logger.info(createKategorieMarker(KATEGORIE_JOURNAL), "{} {}", VERWENDE_STANDARD_KONFIGURATION, nachricht);
                 host = isyTaskConfigurationProperties.getDefault().getHost();
             }
             try {
@@ -148,7 +147,7 @@ public class IsyTaskAspect {
             try {
                 if (!hostHandler.isHostApplicable(host)) {
                     // Simply return and do not execute the task.
-                    logger.info(createKategorieMarker(KATEGORIE_JOURNAL), format("{0} Task {1} wird nicht ausgeführt: Hostname muss \"{2}\" entsprechen.", "ISYTA14101", taskId, host));
+                    logger.info(createKategorieMarker(KATEGORIE_JOURNAL), "{} Task {} wird nicht ausgeführt: Hostname muss \"{}\" entsprechen.", "ISYTA14101", taskId, host);
                     recordFailure(pjp, HostNotApplicableException.class.getSimpleName());
                     return null;
                 }
@@ -163,7 +162,7 @@ public class IsyTaskAspect {
             try {
                 authenticator.login();
             } catch (Exception e) {
-                logger.error(createSchluesselMarker(TECHNIKDATEN), format("{0} Authentifizierung des Tasks {1} fehlgeschlagen. Task wird nicht ausgeführt.", "ISYTA14100", taskId), e);
+                logger.error(createSchluesselMarker(TECHNIKDATEN), "{} Authentifizierung des Tasks {} fehlgeschlagen. Task wird nicht ausgeführt.", "ISYTA14100", taskId, e);
                 return null;
             }
 

--- a/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
@@ -187,5 +187,28 @@ public class IsyTaskAspectTest {
 
     }
 
+    @Test
+    public void testInvokeAndMonitorTask_authenticatorLoginException() throws Throwable {
+
+        // Prepare
+        Authenticator loginException= new Authenticator() {
+            @Override
+            public void login() {
+                throw new RuntimeException("Login Exception");
+            }
+
+            @Override
+            public void logout() {
+
+            }
+        };
+
+        doReturn(loginException).when(authenticatorFactory).getAuthenticator(anyString());
+
+        // Act
+        assertNull(isyTaskAspect.invokeAndMonitorTask(joinPoint));
+
+    }
+
 }
 


### PR DESCRIPTION
* fix: IFS-4526 fix logging substitution in IsyTaskAspect
* test: IFS-4526 add test case for authenticator login Exception
* chore: IFS-4526 update changelog and release notes