### PR TITLE
[Sprint 124] IFS-4495 use defaults if no task config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.0.0
 - `IFS-4576`: Portierung fehlender Tickets aus isy-standards
 - `IFS-4526`: Logeintrag IsyTaskAspect korrigiert
+- `IFS-4495`: Verwendung der Defaults falls keine Task-Config definiert ist
 
 # 4.0.0
 - `IFS-2395`: Umstellung von IsyFact `MessageSourceHolder` auf Spring `MessageSource`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ### Umgesetzte Tickets
 - `IFS-4575`: Portierung fehlender Tickets aus isy-standards
 - `IFS-4526`: Logeintrag IsyTaskAspect korrigiert
+- `IFS-4495`: Verwendung der Defaults falls keine Task-Config definiert ist
 
 #### Bug Fixes
 - keine

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,6 @@
         <spring.framework.version>6.1.6</spring.framework.version>
         <spring.boot.version>3.2.5</spring.boot.version>
 
-        <junit.version>4.13.2</junit.version>
-        <jupiter.version>5.10.2</jupiter.version>
-        <mockito.version>5.14.2</mockito.version>
-        <assertj.version>3.24.2</assertj.version>
-
         <jackson.version>2.18.2</jackson.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
@@ -169,52 +164,21 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>de.bund.bva.isyfact</groupId>
             <artifactId>isy-security-test</artifactId>
             <version>${isy-security-test.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>${spring.framework.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
-            <version>${spring.boot.version}</version>
-            <scope>test</scope>
+            <exclusions>
+              <!-- conflict with junit version from spring-boot-starter-test -->
+              <exclusion>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.assertj</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -228,6 +192,13 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate.validator.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
+++ b/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
@@ -109,17 +109,20 @@ public class IsyTaskAspect {
         if (authenticator == null) {
             throw new RuntimeException(String.format("Authenticator for task %s is null", taskId));
         }
-        String host;
-        boolean isDeactivated;
-        TaskConfig taskConfig;
+
+        String host = null;
+        boolean isDeactivated = false; // tasks are enabled unless configured otherwise;
 
         synchronized (this) {
-            taskConfig = isyTaskConfigurationProperties.getTasks().get(taskId);
-            if (taskConfig == null) {
-                throw new TaskKonfigurationInvalidException(taskId, "Keine Taskkonfiguration vorhanden");
+            TaskConfig taskConfig = isyTaskConfigurationProperties.getTasks().get(taskId);
+            if (taskConfig != null) {
+                isDeactivated = taskConfig.isDeaktiviert();
+                host = taskConfig.getHost();
+            } else {
+                logger.debug("Keine Konfiguration für Task {} gefunden. Es wird auf die Standardwerte zurückgefallen.", taskId);
             }
-            isDeactivated = taskConfig.isDeaktiviert();
-            host = taskConfig.getHost();
+
+            // set default values if not provided by task config
             if (host == null) {
                 String nachricht = messageSource.getMessage(VERWENDE_STANDARD_KONFIGURATION, new String[] { taskId, "hostname" }, Locale.GERMANY);
                 logger.info(createKategorieMarker(KATEGORIE_JOURNAL), "{} {}", VERWENDE_STANDARD_KONFIGURATION, nachricht);

--- a/src/test/java/de/bund/bva/isyfact/task/TestHostHandler.java
+++ b/src/test/java/de/bund/bva/isyfact/task/TestHostHandler.java
@@ -2,12 +2,10 @@ package de.bund.bva.isyfact.task;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import de.bund.bva.isyfact.task.exception.HostNotApplicableException;
 import de.bund.bva.isyfact.task.test.TestTaskRunAssertion;
@@ -15,12 +13,11 @@ import de.bund.bva.isyfact.task.test.config.TestConfig;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-@RunWith(SpringRunner.class)
 @Import(TestHostHandlerTasks.class)
 @SpringBootTest(classes = { TestConfig.class }, webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
-    "isy.logging.anwendung.name=test", "isy.logging.anwendung.typ=test", "isy.logging.anwendung.version=test",
-    "isy.task.tasks.testHostHandlerTasks-scheduledTaskWithCorrectHostname.host=.*",
-    "isy.task.tasks.testHostHandlerTasks-scheduledTaskWithWrongHostname.host=thisisthewronghostname"})
+        "isy.logging.anwendung.name=test", "isy.logging.anwendung.typ=test", "isy.logging.anwendung.version=test",
+        "isy.task.tasks.testHostHandlerTasks-scheduledTaskWithCorrectHostname.host=.*",
+        "isy.task.tasks.testHostHandlerTasks-scheduledTaskWithWrongHostname.host=thisisthewronghostname" })
 public class TestHostHandler {
 
     @Autowired
@@ -34,7 +31,7 @@ public class TestHostHandler {
         SECONDS.sleep(1);
 
         TestTaskRunAssertion.assertTaskSuccess(className, annotatedMethodName, registry,
-            HostNotApplicableException.class.getSimpleName());
+                HostNotApplicableException.class.getSimpleName());
     }
 
     @Test
@@ -45,6 +42,6 @@ public class TestHostHandler {
         SECONDS.sleep(1);
 
         TestTaskRunAssertion.assertTaskFailure(className, annotatedMethodName, registry,
-            HostNotApplicableException.class.getSimpleName());
+                HostNotApplicableException.class.getSimpleName());
     }
 }

--- a/src/test/java/de/bund/bva/isyfact/task/TestTaskDeactivation.java
+++ b/src/test/java/de/bund/bva/isyfact/task/TestTaskDeactivation.java
@@ -2,12 +2,10 @@ package de.bund.bva.isyfact.task;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import de.bund.bva.isyfact.task.exception.TaskDeactivatedException;
 import de.bund.bva.isyfact.task.test.TestTaskRunAssertion;
@@ -15,17 +13,16 @@ import de.bund.bva.isyfact.task.test.config.TestConfig;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-@RunWith(SpringRunner.class)
 @Import(TestTaskDeactivatedTasks.class)
 @SpringBootTest(classes = { TestConfig.class }, webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
-    "isy.logging.anwendung.name=test",
-    "isy.logging.anwendung.typ=test",
-    "isy.logging.anwendung.version=test",
-    "isy.task.authentication.enabled=false",
-    "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskDeactivated.host=.*",
-    "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskDeactivated.deaktiviert=true",
-    "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskActivated.host=.*",
-    "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskActivated.deaktiviert=false"})
+        "isy.logging.anwendung.name=test",
+        "isy.logging.anwendung.typ=test",
+        "isy.logging.anwendung.version=test",
+        "isy.task.authentication.enabled=false",
+        "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskDeactivated.host=.*",
+        "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskDeactivated.deaktiviert=true",
+        "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskActivated.host=.*",
+        "isy.task.tasks.testTaskDeactivatedTasks-scheduledTaskActivated.deaktiviert=false" })
 public class TestTaskDeactivation {
 
     @Autowired
@@ -39,7 +36,7 @@ public class TestTaskDeactivation {
         SECONDS.sleep(1);
 
         TestTaskRunAssertion.assertTaskFailure(className, annotatedMethodName, registry,
-            TaskDeactivatedException.class.getSimpleName());
+                TaskDeactivatedException.class.getSimpleName());
     }
 
     @Test
@@ -50,6 +47,6 @@ public class TestTaskDeactivation {
         SECONDS.sleep(1);
 
         TestTaskRunAssertion.assertTaskSuccess(className, annotatedMethodName, registry,
-            TaskDeactivatedException.class.getSimpleName());
+                TaskDeactivatedException.class.getSimpleName());
     }
 }

--- a/src/test/java/de/bund/bva/isyfact/task/TestTaskScheduledProgrammatically.java
+++ b/src/test/java/de/bund/bva/isyfact/task/TestTaskScheduledProgrammatically.java
@@ -1,18 +1,16 @@
 package de.bund.bva.isyfact.task;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import de.bund.bva.isyfact.task.test.config.TestConfig;
 import de.bund.bva.isyfact.task.util.TaskCounterBuilder;
@@ -20,11 +18,11 @@ import de.bund.bva.isyfact.task.util.TaskCounterBuilder;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-@RunWith(SpringRunner.class)
 @Import(ProgrammaticallyScheduledTask.class)
-@SpringBootTest(classes = TestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {"isy.logging.anwendung.name=test", "isy.logging.anwendung.typ=test",
+@SpringBootTest(classes = TestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+        "isy.logging.anwendung.name=test", "isy.logging.anwendung.typ=test",
         "isy.logging.anwendung.version=test",
-        "isy.task.tasks.programmaticallyScheduledTask-run.host=.*"})
+        "isy.task.tasks.programmaticallyScheduledTask-run.host=.*" })
 public class TestTaskScheduledProgrammatically {
 
     @Autowired
@@ -46,10 +44,10 @@ public class TestTaskScheduledProgrammatically {
         SECONDS.sleep(1);
 
         Counter successCounter = TaskCounterBuilder.successCounter(className, annotatedMethodName, registry);
-        Counter failureCounter = TaskCounterBuilder.failureCounter(className, annotatedMethodName, AuthenticationException.class.getSimpleName(), registry);
+        Counter failureCounter = TaskCounterBuilder.failureCounter(className, annotatedMethodName,
+                AuthenticationException.class.getSimpleName(), registry);
 
         assertEquals(1, successCounter.count(), 0.0);
         assertEquals(0, failureCounter.count(), 0.0);
-
     }
 }

--- a/src/test/java/de/bund/bva/isyfact/task/config/IsyTaskConfigurationPropertiesTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/config/IsyTaskConfigurationPropertiesTest.java
@@ -2,7 +2,7 @@ package de.bund.bva.isyfact.task.config;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class IsyTaskConfigurationPropertiesTest {
 

--- a/src/test/java/de/bund/bva/isyfact/task/konfiguration/impl/LocalHostHandlerImplTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/konfiguration/impl/LocalHostHandlerImplTest.java
@@ -8,8 +8,8 @@ import org.mockito.Mockito;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +24,6 @@ class LocalHostHandlerImplTest {
                 handler.isHostApplicable("TEST");
             });
         }
-
     }
 
 
@@ -47,6 +46,5 @@ class LocalHostHandlerImplTest {
             utilities.when(InetAddress::getLocalHost).thenReturn(address);
             assertFalse(handler.isHostApplicable("TEST"));
         }
-
     }
 }

--- a/src/test/java/de/bund/bva/isyfact/task/security/impl/IsySecurityAuthenticatorFactoryTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/security/impl/IsySecurityAuthenticatorFactoryTest.java
@@ -19,10 +19,10 @@ import de.bund.bva.isyfact.task.test.config.TestConfig;
 class IsySecurityAuthenticatorFactoryTest {
 
     @Autowired
-    AuthenticatorFactory authFactory;
+    private AuthenticatorFactory authFactory;
 
     @Autowired
-    IsyTaskConfigurationProperties isyTaskConfigurationProperties;
+    private IsyTaskConfigurationProperties isyTaskConfigurationProperties;
 
     @Test
     void getAuthenticator_doesNotThrowWithUnknownTaskId() {

--- a/src/test/java/de/bund/bva/isyfact/task/test/TestTaskRunAssertion.java
+++ b/src/test/java/de/bund/bva/isyfact/task/test/TestTaskRunAssertion.java
@@ -1,7 +1,7 @@
 package de.bund.bva.isyfact.task.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.bund.bva.isyfact.task.util.TaskCounterBuilder;
 
@@ -11,22 +11,22 @@ import io.micrometer.core.instrument.MeterRegistry;
 public class TestTaskRunAssertion {
 
     public static void assertTaskSuccess(String className, String annotatedMethodName,
-        MeterRegistry registry, String exceptionName){
+            MeterRegistry registry, String exceptionName) {
 
         Counter successCounter = TaskCounterBuilder.successCounter(className, annotatedMethodName, registry);
         Counter failureCounter = TaskCounterBuilder.failureCounter(className, annotatedMethodName,
-            exceptionName, registry);
+                exceptionName, registry);
 
         assertTrue(successCounter.count() > 0);
         assertEquals(0, failureCounter.count(), 0.0);
     }
 
     public static void assertTaskFailure(String className, String annotatedMethodName,
-        MeterRegistry registry, String exceptionName){
+            MeterRegistry registry, String exceptionName) {
 
         Counter successCounter = TaskCounterBuilder.successCounter(className, annotatedMethodName, registry);
         Counter failureCounter = TaskCounterBuilder.failureCounter(className, annotatedMethodName,
-            exceptionName, registry);
+                exceptionName, registry);
 
         assertEquals(0, successCounter.count(), 0.0);
         assertTrue(failureCounter.count() > 0);

--- a/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
@@ -101,18 +101,16 @@ public class IsyTaskAspectTest {
     }
 
     @Test
-    public void testInvokeAndMonitorTask_noTaskConfig() throws Throwable {
+    public void testInvokeAndMonitorTask_noTaskConfigUseDefault() throws Throwable {
         // Prepare
         properties.getTasks().clear();
 
         // Act
-        TaskKonfigurationInvalidException taskKonfigurationInvalidException =
-                assertThrows(TaskKonfigurationInvalidException.class,
-                        () -> isyTaskAspect.invokeAndMonitorTask(joinPoint));
+        isyTaskAspect.invokeAndMonitorTask(joinPoint);
 
-        // Assert
-        assertEquals("[ISYTA00003] Task-Konfiguration ungültig: Keine Taskkonfiguration vorhanden.",
-                taskKonfigurationInvalidException.getMessage());
+        // Verify
+        verify(hostHandler).isHostApplicable(properties.getDefault().getHost());
+        verify(joinPoint).proceed();
     }
 
     @Test

--- a/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
@@ -1,5 +1,29 @@
 package de.bund.bva.isyfact.task.test.monitoring;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.support.ResourceBundleMessageSource;
+
 import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties;
 import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties.TaskConfig;
 import de.bund.bva.isyfact.task.exception.TaskKonfigurationInvalidException;
@@ -7,59 +31,42 @@ import de.bund.bva.isyfact.task.konfiguration.HostHandler;
 import de.bund.bva.isyfact.task.monitoring.IsyTaskAspect;
 import de.bund.bva.isyfact.task.security.Authenticator;
 import de.bund.bva.isyfact.task.security.AuthenticatorFactory;
-import io.micrometer.core.instrument.Counter;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.Signature;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.context.support.ResourceBundleMessageSource;
 
-import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
-
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class IsyTaskAspectTest {
-    @Mock
-    ProceedingJoinPoint joinPoint;
 
     @Mock
-    AuthenticatorFactory authenticatorFactory;
+    private ProceedingJoinPoint joinPoint;
 
     @Mock
-    Authenticator authenticator;
+    private AuthenticatorFactory authenticatorFactory;
 
     @Mock
-    HostHandler hostHandler;
+    private Authenticator authenticator;
+
+    @Mock
+    private HostHandler hostHandler;
 
     @InjectMocks
-    IsyTaskAspect isyTaskAspect;
-
-    @Mock
-    Counter counter;
+    private IsyTaskAspect isyTaskAspect;
 
     @Spy
-    IsyTaskConfigurationProperties properties = new IsyTaskConfigurationProperties();
+    private IsyTaskConfigurationProperties properties = new IsyTaskConfigurationProperties();
 
     @Spy
-    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @Spy
-    ResourceBundleMessageSource resourceBundleMessageSource = new ResourceBundleMessageSource();
+    private ResourceBundleMessageSource resourceBundleMessageSource = new ResourceBundleMessageSource();
 
-    TaskConfig testTaskConfig;
+    private TaskConfig testTaskConfig;
 
-    @Before
+    @BeforeEach
     public void prepare() throws Exception {
         testTaskConfig = new TaskConfig();
         testTaskConfig.setHost("myHost");
@@ -67,24 +74,22 @@ public class IsyTaskAspectTest {
 
         taskConfigMap.put("class-myClass", testTaskConfig);
 
-        doReturn(authenticator).when(authenticatorFactory).getAuthenticator(anyString());
+        when(authenticatorFactory.getAuthenticator(anyString())).thenReturn(authenticator);
 
         resourceBundleMessageSource.setBasenames("messages");
 
         joinPoint = mock(ProceedingJoinPoint.class);
         JoinPoint.StaticPart staticPart = mock(JoinPoint.StaticPart.class);
-        doReturn(staticPart).when(joinPoint).getStaticPart();
+        when(joinPoint.getStaticPart()).thenReturn(staticPart);
         Signature signature = mock(Signature.class);
-        doReturn(true).when(hostHandler).isHostApplicable(anyString());
-        doReturn(signature).when(staticPart).getSignature();
-        doReturn(Class.class).when(signature).getDeclaringType();
-        doReturn("myClass").when(signature).getName();
-
+        when(hostHandler.isHostApplicable(anyString())).thenReturn(true);
+        when(staticPart.getSignature()).thenReturn(signature);
+        when(signature.getDeclaringType()).thenReturn(Class.class);
+        when(signature.getName()).thenReturn("myClass");
     }
 
     @Test
     public void testInvokeAndMonitorTask_Success() throws Throwable {
-
         // Prepare
 
         // Act
@@ -96,8 +101,7 @@ public class IsyTaskAspectTest {
     }
 
     @Test
-    public void testInvokeAndMonitorTask_noTaskConfig() {
-
+    public void testInvokeAndMonitorTask_noTaskConfig() throws Throwable {
         // Prepare
         properties.getTasks().clear();
 
@@ -107,15 +111,13 @@ public class IsyTaskAspectTest {
                         () -> isyTaskAspect.invokeAndMonitorTask(joinPoint));
 
         // Assert
-        assertEquals("ISYTA00003", taskKonfigurationInvalidException.getAusnahmeId());
-        assertEquals("[ISYTA00003] Task-Konfiguration für Task class-myClass ungültig: Keine Taskkonfiguration vorhanden.", taskKonfigurationInvalidException.getFehlertext());
+        assertEquals("[ISYTA00003] Task-Konfiguration ungültig: Keine Taskkonfiguration vorhanden.",
+                taskKonfigurationInvalidException.getMessage());
     }
 
     @Test
-    public void testInvokeAndMonitorTask_hostnameInvalidRegex() {
-
+    public void testInvokeAndMonitorTask_hostnameInvalidRegex() throws Throwable {
         // Prepare
-
         testTaskConfig.setHost("(");
 
         // Act
@@ -124,13 +126,12 @@ public class IsyTaskAspectTest {
                         () -> isyTaskAspect.invokeAndMonitorTask(joinPoint));
 
         // Assert
-        assertEquals("ISYTA00003", taskKonfigurationInvalidException.getAusnahmeId());
-        assertEquals("[ISYTA00003] Task-Konfiguration für Task class-myClass ungültig: Hostname ist keine gültige Regex.", taskKonfigurationInvalidException.getFehlertext());
+        assertEquals("[ISYTA00003] Task-Konfiguration für Task class-myClass ungültig: Hostname ist keine gültige Regex.",
+                taskKonfigurationInvalidException.getMessage());
     }
 
     @Test
     public void testInvokeAndMonitorTask_hostnameNullUseDefault() throws Throwable {
-
         // Prepare
         testTaskConfig.setHost(null);
 
@@ -144,21 +145,18 @@ public class IsyTaskAspectTest {
 
     @Test
     public void testInvokeAndMonitorTask_hostnameNotApplicable() throws Throwable {
-
         // Prepare
-        doReturn(false).when(hostHandler).isHostApplicable(anyString());
+        when(hostHandler.isHostApplicable(anyString())).thenReturn(false);
 
         // Act
         isyTaskAspect.invokeAndMonitorTask(joinPoint);
 
         // Assert
         assertNull(isyTaskAspect.invokeAndMonitorTask(joinPoint));
-
     }
 
     @Test
     public void testInvokeAndMonitorTask_taskIsDeactivated() throws Throwable {
-
         // Prepare
         testTaskConfig.setDeaktiviert(true);
 
@@ -167,14 +165,12 @@ public class IsyTaskAspectTest {
 
         // Assert
         assertNull(isyTaskAspect.invokeAndMonitorTask(joinPoint));
-
     }
 
     @Test
-    public void testInvokeAndMonitorTask_authenticatorNull() {
-
+    public void testInvokeAndMonitorTask_authenticatorNull() throws Throwable {
         // Prepare
-        doReturn(null).when(authenticatorFactory).getAuthenticator(anyString());
+        when(authenticatorFactory.getAuthenticator(anyString())).thenReturn(null);
 
         // Act
         RuntimeException runtimeException =
@@ -203,12 +199,10 @@ public class IsyTaskAspectTest {
             }
         };
 
-        doReturn(loginException).when(authenticatorFactory).getAuthenticator(anyString());
+        when(authenticatorFactory.getAuthenticator(anyString())).thenReturn(loginException);
 
         // Act
         assertNull(isyTaskAspect.invokeAndMonitorTask(joinPoint));
-
     }
 
 }
-


### PR DESCRIPTION
* fix: IFS-4526 fix logging substitution in IsyTaskAspect
* test: IFS-4526 add test case for authenticator login Exception
* chore: IFS-4526 update changelog and release notes
* Merge pull request #31 from IsyFact/feature/IFS-4526-isy-task-Logeintrag-fehlerhaft-5.x

    [Sprint 124] IFS-4526 isy task Logeintrag fehlerhaft 5.x

* test: IFS-4495 migrate tests to JUnit 5
* feat: IFS-4495 use default if a task has no TaskConfig
* chore: IFS-4495 update release notes and changelog