### PR TITLE
[Sprint 128] IFS-4601 lizenzheader bereinigen

### DIFF
--- a/src/main/java/de/bund/bva/isyfact/task/annotation/OnceTask.java
+++ b/src/main/java/de/bund/bva/isyfact/task/annotation/OnceTask.java
@@ -1,20 +1,3 @@
-/*
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.
- * The Federal Office of Administration (Bundesverwaltungsamt, BVA)
- * licenses this file to you under the Apache License, Version 2.0 (the
- * License). You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package de.bund.bva.isyfact.task.annotation;
 
 public @interface OnceTask {

--- a/src/main/java/de/bund/bva/isyfact/task/autoconfigure/IsyTaskAutoConfiguration.java
+++ b/src/main/java/de/bund/bva/isyfact/task/autoconfigure/IsyTaskAutoConfiguration.java
@@ -1,15 +1,5 @@
 package de.bund.bva.isyfact.task.autoconfigure;
 
-import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
-import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties;
-import de.bund.bva.isyfact.task.konfiguration.HostHandler;
-import de.bund.bva.isyfact.task.konfiguration.impl.LocalHostHandlerImpl;
-import de.bund.bva.isyfact.task.monitoring.IsyTaskAspect;
-import de.bund.bva.isyfact.task.security.AuthenticatorFactory;
-import de.bund.bva.isyfact.task.security.impl.IsySecurityAuthenticatorFactory;
-import de.bund.bva.isyfact.task.security.impl.NoOpAuthenticatorFactory;
-import io.micrometer.core.aop.TimedAspect;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -21,6 +11,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
+import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties;
+import de.bund.bva.isyfact.task.konfiguration.HostHandler;
+import de.bund.bva.isyfact.task.konfiguration.impl.LocalHostHandlerImpl;
+import de.bund.bva.isyfact.task.monitoring.IsyTaskAspect;
+import de.bund.bva.isyfact.task.security.AuthenticatorFactory;
+import de.bund.bva.isyfact.task.security.impl.IsySecurityAuthenticatorFactory;
+import de.bund.bva.isyfact.task.security.impl.NoOpAuthenticatorFactory;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
 
 @Configuration
 @EnableConfigurationProperties

--- a/src/main/java/de/bund/bva/isyfact/task/exception/TaskException.java
+++ b/src/main/java/de/bund/bva/isyfact/task/exception/TaskException.java
@@ -1,8 +1,8 @@
 package de.bund.bva.isyfact.task.exception;
 
-import java.io.Serial;
-
 import static de.bund.bva.isyfact.util.text.MessageProvider.createMessage;
+
+import java.io.Serial;
 
 public class TaskException extends Exception {
 

--- a/src/main/java/de/bund/bva/isyfact/task/exception/TaskRuntimeException.java
+++ b/src/main/java/de/bund/bva/isyfact/task/exception/TaskRuntimeException.java
@@ -1,8 +1,8 @@
 package de.bund.bva.isyfact.task.exception;
 
-import java.io.Serial;
-
 import static de.bund.bva.isyfact.util.text.MessageProvider.createMessage;
+
+import java.io.Serial;
 
 public class TaskRuntimeException extends RuntimeException {
 

--- a/src/main/java/de/bund/bva/isyfact/task/konfiguration/impl/LocalHostHandlerImpl.java
+++ b/src/main/java/de/bund/bva/isyfact/task/konfiguration/impl/LocalHostHandlerImpl.java
@@ -1,12 +1,13 @@
 package de.bund.bva.isyfact.task.konfiguration.impl;
 
-import de.bund.bva.isyfact.task.exception.HostNotApplicableException;
-import de.bund.bva.isyfact.task.konfiguration.HostHandler;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import de.bund.bva.isyfact.task.exception.HostNotApplicableException;
+import de.bund.bva.isyfact.task.konfiguration.HostHandler;
 
 /**
  * The HostHandler is a utility class that checks a host instance.

--- a/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
+++ b/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
@@ -1,5 +1,23 @@
 package de.bund.bva.isyfact.task.monitoring;
 
+import static de.bund.bva.isyfact.task.konstanten.HinweisSchluessel.VERWENDE_STANDARD_KONFIGURATION;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.*;
+
+import java.util.Locale;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.MessageSource;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
 import de.bund.bva.isyfact.logging.util.MdcHelper;
 import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties;
 import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties.TaskConfig;
@@ -12,25 +30,9 @@ import de.bund.bva.isyfact.task.security.Authenticator;
 import de.bund.bva.isyfact.task.security.AuthenticatorFactory;
 import de.bund.bva.isyfact.task.util.TaskCounterBuilder;
 import de.bund.bva.isyfact.task.util.TaskId;
+
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.annotation.Around;
-import org.aspectj.lang.annotation.Aspect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.MessageSource;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-
-import java.util.Locale;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
-import static de.bund.bva.isyfact.task.konstanten.HinweisSchluessel.VERWENDE_STANDARD_KONFIGURATION;
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.*;
 
 @Aspect
 @Order(Ordered.HIGHEST_PRECEDENCE)

--- a/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
+++ b/src/main/java/de/bund/bva/isyfact/task/monitoring/IsyTaskAspect.java
@@ -1,20 +1,3 @@
-/*
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.
- * The Federal Office of Administration (Bundesverwaltungsamt, BVA)
- * licenses this file to you under the Apache License, Version 2.0 (the
- * License). You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package de.bund.bva.isyfact.task.monitoring;
 
 import de.bund.bva.isyfact.logging.util.MdcHelper;

--- a/src/main/java/de/bund/bva/isyfact/task/security/Authenticator.java
+++ b/src/main/java/de/bund/bva/isyfact/task/security/Authenticator.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package de.bund.bva.isyfact.task.security;
 
 /**

--- a/src/main/java/de/bund/bva/isyfact/task/security/impl/IsySecurityAuthenticatorFactory.java
+++ b/src/main/java/de/bund/bva/isyfact/task/security/impl/IsySecurityAuthenticatorFactory.java
@@ -1,19 +1,20 @@
 package de.bund.bva.isyfact.task.security.impl;
 
-import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
-import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties;
-import de.bund.bva.isyfact.task.konstanten.HinweisSchluessel;
-import de.bund.bva.isyfact.task.security.Authenticator;
-import de.bund.bva.isyfact.task.security.AuthenticatorFactory;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_SICHERHEIT;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+
+import java.util.Locale;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
 import org.springframework.util.StringUtils;
 
-import java.util.Locale;
-
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_SICHERHEIT;
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
+import de.bund.bva.isyfact.task.config.IsyTaskConfigurationProperties;
+import de.bund.bva.isyfact.task.konstanten.HinweisSchluessel;
+import de.bund.bva.isyfact.task.security.Authenticator;
+import de.bund.bva.isyfact.task.security.AuthenticatorFactory;
 
 /**
  * Creates Authenticators for authentication with isy-security.

--- a/src/main/java/de/bund/bva/isyfact/task/util/TaskCounterBuilder.java
+++ b/src/main/java/de/bund/bva/isyfact/task/util/TaskCounterBuilder.java
@@ -1,20 +1,3 @@
-/*
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.
- * The Federal Office of Administration (Bundesverwaltungsamt, BVA)
- * licenses this file to you under the Apache License, Version 2.0 (the
- * License). You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package de.bund.bva.isyfact.task.util;
 
 import java.util.function.Function;

--- a/src/main/java/de/bund/bva/isyfact/task/util/TaskId.java
+++ b/src/main/java/de/bund/bva/isyfact/task/util/TaskId.java
@@ -1,20 +1,3 @@
-/*
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.
- * The Federal Office of Administration (Bundesverwaltungsamt, BVA)
- * licenses this file to you under the Apache License, Version 2.0 (the
- * License). You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package de.bund.bva.isyfact.task.util;
 
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,19 +1,3 @@
-###
-# See the NOTICE file distributed with this work for additional
-# information regarding copyright ownership.
-# The Federal Office of Administration (Bundesverwaltungsamt, BVA)
-# licenses this file to you under the Apache License, Version 2.0 (the
-# License). You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied. See the License for the specific language governing
-# permissions and limitations under the License.
-###
 ISYTA00001=Task wird nicht ausgef\u00FChrt. Hostname unpassend: {0}.
 ISYTA00002=Task {0} konnte nicht zur Ausf\u00FChrung eingereiht werden.
 ISYTA00003=Task-Konfiguration f\u00FCr Task {0} ung\u00FCltig: {1}.

--- a/src/test/java/de/bund/bva/isyfact/task/ProgrammaticallyScheduledTask.java
+++ b/src/test/java/de/bund/bva/isyfact/task/ProgrammaticallyScheduledTask.java
@@ -1,17 +1,18 @@
 package de.bund.bva.isyfact.task;
 
-import de.bund.bva.isyfact.task.annotation.OnceTask;
-import de.bund.bva.isyfact.task.demo.ScheduledTasks;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import de.bund.bva.isyfact.task.annotation.OnceTask;
+import de.bund.bva.isyfact.task.demo.ScheduledTasks;
 
 @Component
 public class ProgrammaticallyScheduledTask implements Runnable {

--- a/src/test/java/de/bund/bva/isyfact/task/TestHostHandlerTasks.java
+++ b/src/test/java/de/bund/bva/isyfact/task/TestHostHandlerTasks.java
@@ -1,16 +1,17 @@
 package de.bund.bva.isyfact.task;
 
-import io.micrometer.core.annotation.Timed;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
-
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+import io.micrometer.core.annotation.Timed;
 
 @Component
 public class TestHostHandlerTasks {

--- a/src/test/java/de/bund/bva/isyfact/task/TestTaskAuthenticationTasks.java
+++ b/src/test/java/de/bund/bva/isyfact/task/TestTaskAuthenticationTasks.java
@@ -1,16 +1,16 @@
 package de.bund.bva.isyfact.task;
 
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
-
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
 
 @Component
 public class TestTaskAuthenticationTasks {

--- a/src/test/java/de/bund/bva/isyfact/task/TestTaskDeactivatedTasks.java
+++ b/src/test/java/de/bund/bva/isyfact/task/TestTaskDeactivatedTasks.java
@@ -1,15 +1,15 @@
 package de.bund.bva.isyfact.task;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_JOURNAL;
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 @Component
 public class TestTaskDeactivatedTasks {

--- a/src/test/java/de/bund/bva/isyfact/task/config/IsyTaskConfigurationPropertiesTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/config/IsyTaskConfigurationPropertiesTest.java
@@ -1,8 +1,8 @@
 package de.bund.bva.isyfact.task.config;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 class IsyTaskConfigurationPropertiesTest {
 

--- a/src/test/java/de/bund/bva/isyfact/task/demo/ScheduledTasks.java
+++ b/src/test/java/de/bund/bva/isyfact/task/demo/ScheduledTasks.java
@@ -1,18 +1,19 @@
 package de.bund.bva.isyfact.task.demo;
 
-import io.micrometer.core.annotation.Timed;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_SICHERHEIT;
+import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.KATEGORIE_SICHERHEIT;
-import static de.bund.bva.isyfact.util.logging.CombinedMarkerFactory.createKategorieMarker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.annotation.Timed;
 
 @Component
 public class ScheduledTasks {

--- a/src/test/java/de/bund/bva/isyfact/task/exception/TaskDeactivatedExceptionTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/exception/TaskDeactivatedExceptionTest.java
@@ -1,8 +1,8 @@
 package de.bund.bva.isyfact.task.exception;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 class TaskDeactivatedExceptionTest {
 

--- a/src/test/java/de/bund/bva/isyfact/task/konfiguration/impl/LocalHostHandlerImplTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/konfiguration/impl/LocalHostHandlerImplTest.java
@@ -1,17 +1,17 @@
 package de.bund.bva.isyfact.task.konfiguration.impl;
 
-import de.bund.bva.isyfact.task.exception.HostNotApplicableException;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import de.bund.bva.isyfact.task.exception.HostNotApplicableException;
 
 class LocalHostHandlerImplTest {
 

--- a/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
+++ b/src/test/java/de/bund/bva/isyfact/task/test/monitoring/IsyTaskAspectTest.java
@@ -4,9 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Map;
 

--- a/src/test/resources/messages.properties
+++ b/src/test/resources/messages.properties
@@ -1,19 +1,3 @@
-###
-# See the NOTICE file distributed with this work for additional
-# information regarding copyright ownership.
-# The Federal Office of Administration (Bundesverwaltungsamt, BVA)
-# licenses this file to you under the Apache License, Version 2.0 (the
-# License). You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied. See the License for the specific language governing
-# permissions and limitations under the License.
-###
 ISYTA00001=Task wird nicht ausgef\u00FChrt. Hostname unpassend: {0}.
 ISYTA00002=Task {0} konnte nicht zur Ausf\u00FChrung eingereiht werden.
 ISYTA00003=Task-Konfiguration f\u00FCr Task {0} ung\u00FCltig: {1}.


### PR DESCRIPTION
* feat: IFS-4601 removes javadoc license information in each class
* feat: IFS-4601 removes empty javadoc blocks
* refactor: IFS-4601 optimizes imports
* feat: IFS-4601 removes javadoc license information in properties file